### PR TITLE
Setup CI for building and releasing mod

### DIFF
--- a/Submerged/.github/workflows/ci.yml
+++ b/Submerged/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build Debug
+        run: dotnet build --configuration Debug --no-restore
+      - name: Build Release
+        run: dotnet build --configuration Release --no-restore
+      - name: Upload Debug Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: submerged-debug
+          path: Submerged/bin/Debug/net6.0/Submerged.dll
+      - name: Upload Release Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: submerged-release
+          path: Submerged/bin/Release/net6.0/Submerged.dll
+      - name: Setup Draft Release
+        if: github.ref == 'refs/heads/main'
+        run: echo "Draft release steps to be implemented"

--- a/Submerged/build_data.json
+++ b/Submerged/build_data.json
@@ -1,0 +1,16 @@
+{
+    "build": {
+        "path": "BepInEx/plugins"
+    },
+    "dependencies": {
+        "BepInEx": {
+            "download": "https://builds.bepinex.dev/projects/bepinex_be/688/BepInEx-Unity.IL2CPP-win-x86-6.0.0-be.688%2B4901521.zip",
+            "path": ".",
+            "unarchive": true
+        },
+        "Reactor": {
+            "download": "https://github.com/NuclearPowered/Reactor/releases/download/2.2.0/Reactor.dll",
+            "path": "BepInEx/plugins"
+        }
+    }
+}


### PR DESCRIPTION
Related to #149

Implements CI workflow and adds build data file as specified.
- Adds a new GitHub Actions workflow file `ci.yml` to automate the build process, including steps for restoring NuGet packages, building the mod in both debug and release configurations, and uploading the resulting DLLs as artifacts.
- Introduces a `build_data.json` file containing the specified JSON structure for build path and dependencies, including download links and paths for BepInEx and Reactor dependencies.

---